### PR TITLE
Update main.py

### DIFF
--- a/TCSA/Subsystem/miniCapa/main.py
+++ b/TCSA/Subsystem/miniCapa/main.py
@@ -387,7 +387,7 @@ def find_capabilities(ruleset: RuleSet, extractor: FeatureExtractor, disable_pro
 
     # pb = pbar(functions, desc="matching", unit=" functions", postfix="skipped 0 library functions")
     for f in functions:
-        function_address = int(f)
+        function_address = int(f.address)
 
         if extractor.is_library_function(function_address):
             function_name = extractor.get_function_name(function_address)
@@ -464,7 +464,7 @@ def find_function_capabilities(ruleset: RuleSet, extractor: FeatureExtractor, f:
                 bb_features[feature].add(va)
                 function_features[feature].add(va)
 
-        _, matches = ruleset.match(Scope.BASIC_BLOCK, bb_features, int(bb))
+        _, matches = ruleset.match(Scope.BASIC_BLOCK, bb_features, int(bb.address))
         # print(f, matches)
 
         for rule_name, res in matches.items():
@@ -477,7 +477,7 @@ def find_function_capabilities(ruleset: RuleSet, extractor: FeatureExtractor, f:
             # res = [(int(f),_) for va, _ in res]    
             bb_matches[rule_name].extend(res)
 
-    _, function_matches = ruleset.match(Scope.FUNCTION, function_features, int(f))
+    _, function_matches = ruleset.match(Scope.FUNCTION, function_features, int(f.address))
     # print("function_matches: ", function_matches)
     # print("bb_matches: ", bb_matches)
 


### PR DESCRIPTION
fix the error ( see below ) 

concurrent.futures.process._RemoteTraceback: 
"""
Traceback (most recent call last):
  File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.9_3.9.3568.0_x64__qbz5n2kfra8p0\lib\concurrent\futures\process.py", line 246, in _process_worker
    r = call_item.fn(*call_item.args, **call_item.kwargs)
  File "C:\Users\MikeLiang\Downloads\TCSA-main\TCSA\Subsystem\miniCapa\main.py", line 546, in capaScan
    return main(vw, pathToSample, pathToRules)
  File "C:\Users\MikeLiang\Downloads\TCSA-main\TCSA\Subsystem\miniCapa\main.py", line 71, in main
    capabilities, counts = find_capabilities(rules, extractor, disable_progress=True)
  File "C:\Users\MikeLiang\Downloads\TCSA-main\TCSA\Subsystem\miniCapa\main.py", line 390, in find_capabilities
    function_address = int(f)
TypeError: int() argument must be a string, a bytes-like object or a number, not 'FunctionHandle'
"""

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "C:\Users\MikeLiang\Downloads\TCSA-main\TCSA\tcsa.py", line 504, in <module>
    capaMatchRet = task_miniCapa.result() if not "-noCapa" in sys.argv else {}
  File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.9_3.9.3568.0_x64__qbz5n2kfra8p0\lib\concurrent\futures\_base.py", line 439, in result
    return self.__get_result()
  File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.9_3.9.3568.0_x64__qbz5n2kfra8p0\lib\concurrent\futures\_base.py", line 391, in __get_result
    raise self._exception
TypeError: int() argument must be a string, a bytes-like object or a number, not 'FunctionHandle'
